### PR TITLE
Fixes `serde::export` private module error

### DIFF
--- a/src/video_info/player_response/streaming_data/serde_impl/signature_cipher.rs
+++ b/src/video_info/player_response/streaming_data/serde_impl/signature_cipher.rs
@@ -4,7 +4,7 @@ use url::Url;
 
 use crate::video_info::player_response::streaming_data::SignatureCipher;
 
-pub(crate) fn deserialize<'de, D>(deserializer: D) -> serde::export::Result<SignatureCipher, D::Error>
+pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<SignatureCipher, D::Error>
     where
         D: serde_with::serde::Deserializer<'de> {
     #[derive(Deserialize)]


### PR DESCRIPTION
I've been having this error trying to use this library, and I might as well fix it.

Good job on this though, this is a great library IMO.
