### PR TITLE
Used default implementation if formats is not given

### DIFF
--- a/src/video_info/player_response/streaming_data/mod.rs
+++ b/src/video_info/player_response/streaming_data/mod.rs
@@ -15,6 +15,7 @@ pub struct StreamingData {
     pub adaptive_formats: Vec<RawFormat>,
     #[serde_as(as = "JsonString")]
     pub expires_in_seconds: u64,
+    #[serde(default)]
     pub formats: Vec<RawFormat>,
 }
 


### PR DESCRIPTION
This fixes at least the fetch phase of live streams. Downloading live streams still doesn't work