### PR TITLE
Reorganize callback a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ tokio-test = "0.4.0"
 [features]
 # By default, the minimal features for downloading a video are enabled. If you compile with default-features = false,
 # you get only the Id type as well as the Error type. 
-default = ["download", "std", "default-tls"]
+default = ["download", "std", "default-tls", "callback"]
 std = ["regex", "thiserror"]
-callback = ["tokio/sync", "tokio/rt", "futures", "download"]
+callback = ["tokio/sync", "futures", "download"]
 microformat = ["fetch", "chrono/serde"]
 download = [
     "fetch", "tokio/fs", "tokio/io-util", "tokio/parking_lot", "tokio-stream"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tokio-test = "0.4.0"
 [features]
 # By default, the minimal features for downloading a video are enabled. If you compile with default-features = false,
 # you get only the Id type as well as the Error type. 
-default = ["download", "std", "default-tls", "callback"]
+default = ["download", "std", "default-tls"]
 std = ["regex", "thiserror"]
 callback = ["tokio/sync", "futures", "download"]
 microformat = ["fetch", "chrono/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,12 @@ unreachable_pub
 //! 
 //! [`Stream::download_to_dir`] and [`Stream::download_to`] have your back! Those methods allow you
 //! to specify exactly, where the video should be downloaded too.
+//!
+//! If you want to do something, while the download is progressing, enable the `callback`
+//! feature and use the then availabe `*_callback` methods, for example
+//! [`Stream::download_callback`].
+//!
+//! The [`Callback`] struct can take up to one `on_progress` method and one `on_complete` method.
 //! 
 //! ## Feature flags
 //! One of the goals of `rustube` is to eventually deserialize the complete video information, so 
@@ -164,6 +170,7 @@ unreachable_pub
 //! - `blocking`: Enables the [`blocking`] API, which internally creates a [`tokio`] runtime for you
 //!   , so you don't have to care about it yourself. (Keep in mind, that this feature does not enable
 //!   any of the other features above automatically)
+//! - `callback`: Enables to add callbacks to downlaods and the [`Callback`] struct itself
 //! 
 //!
 //! [view count]: crate::video_info::player_response::video_details::VideoDetails::view_count 

--- a/src/stream/callback.rs
+++ b/src/stream/callback.rs
@@ -286,7 +286,7 @@ impl super::Stream {
 
     #[inline]
     async fn on_progress(mut receiver: Receiver<InternalSignal>, on_progress: OnProgressType) {
-        let counter = Mutex::new(100);
+        let last_trigger = Mutex::new(100);
         match on_progress {
             OnProgressType::None => {}
             OnProgressType::Closure(closure) => {
@@ -329,10 +329,11 @@ impl super::Stream {
                 while let Some(data) = receiver.recv().await {
                     match data {
                         InternalSignal::Value(data) => {
-                            if let Ok(mut counter) = counter.try_lock() {
-                                *counter += 1;
-                                if *counter > 100 {
-                                    *counter = 0;
+                            if let Ok(mut trigger) = last_trigger.try_lock() {
+                                // discard any digits beyond the million digit
+                                let current_million = data / 1_000_000;
+                                if *trigger < current_million {
+                                    *trigger = current_million;
                                     let arguments = CallbackArguments { current_chunk: data };
                                     closure(arguments)
                                 }
@@ -346,10 +347,11 @@ impl super::Stream {
                 while let Some(data) = receiver.recv().await {
                     match data {
                         InternalSignal::Value(data) => {
-                            if let Ok(mut counter) = counter.try_lock() {
-                                *counter += 1;
-                                if *counter > 100 {
-                                    *counter = 0;
+                            if let Ok(mut trigger) = last_trigger.try_lock() {
+                                // discard any digits beyond the million digit
+                                let current_million = data / 1_000_000;
+                                if *trigger < current_million {
+                                    *trigger = current_million;
                                     let arguments = CallbackArguments { current_chunk: data };
                                     closure(arguments).await
                                 }
@@ -363,10 +365,11 @@ impl super::Stream {
                 while let Some(data) = receiver.recv().await {
                     match data {
                         InternalSignal::Value(data) => {
-                            if let Ok(mut counter) = counter.try_lock() {
-                                *counter += 1;
-                                if *counter > 100 {
-                                    *counter = 0;
+                            if let Ok(mut trigger) = last_trigger.try_lock() {
+                                // discard any digits beyond the million digit
+                                let current_million = data / 1_000_000;
+                                if *trigger < current_million {
+                                    *trigger = current_million;
                                     let arguments = CallbackArguments { current_chunk: data };
                                     if sender.send(arguments).await.is_err() && cancel_on_close {
                                         receiver.close()

--- a/src/stream/callback.rs
+++ b/src/stream/callback.rs
@@ -286,7 +286,7 @@ impl super::Stream {
 
     #[inline]
     async fn on_progress(mut receiver: Receiver<InternalSignal>, on_progress: OnProgressType) {
-        let last_trigger = Mutex::new(100);
+        let last_trigger = Mutex::new(0);
         match on_progress {
             OnProgressType::None => {}
             OnProgressType::Closure(closure) => {

--- a/src/stream/callback.rs
+++ b/src/stream/callback.rs
@@ -260,9 +260,10 @@ impl super::Stream {
     #[doc(cfg(feature = "callback"))]
     #[inline]
     pub async fn download_to_callback<P: AsRef<Path>>(&self, path: P, callback: Callback) -> Result<()> {
-        Self::wrap_callback(|channel| {
+        let _ = Self::wrap_callback(|channel| {
             self.internal_download_to(path, channel)
-        }, callback).await.map(|_| ())
+        }, callback).await?;
+        Ok(())
     }
 
     async fn wrap_callback<F: Future<Output = Result<PathBuf>>>(

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -239,11 +239,7 @@ impl Stream {
                 tokio::fs::remove_file(path.as_ref()).await?;
                 Err(e)
             }
-        }.map(|_| {
-            let mut pathbuf = PathBuf::new();
-            pathbuf.push(path);
-            pathbuf
-        });
+        }.map(|_| path.as_ref().to_path_buf());
 
         #[cfg(feature = "callback")]
         if let Some(channel) = channel {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -201,7 +201,8 @@ impl Stream {
     /// This will download the video to the provided file path.
     #[inline]
     pub async fn download_to<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        self.internal_download_to(path, None).await.map(|_| ())
+        let _ = self.internal_download_to(path, None).await?;
+        Ok(())
     }
 
     #[allow(unused_mut)]
@@ -246,7 +247,7 @@ impl Stream {
 
         #[cfg(feature = "callback")]
         if let Some(channel) = channel {
-            channel.send(InternalSignal::Finished).await.unwrap_or(())
+            let _ = channel.send(InternalSignal::Finished).await;
         }
 
         result

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -43,7 +43,7 @@ pub mod callback;
 //  there are different types of streams: video, audio, and video + audio
 //  make Stream and RawFormat an enum, so there are less options in it
 
-#[cfg(not(any(feature = "callback", doc)))]
+#[cfg(all(not(feature = "callback"), feature = "download"))]
 type InternalCommunication = ();
 
 /// A downloadable video Stream, that contains all the important information. 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -172,7 +172,6 @@ impl Stream {
             .with_extension("mp4");
         self.internal_download_to(&path, channel)
             .await
-            .map(|_| path)
     }
 
     /// Attempts to downloads the [`Stream`]s resource.
@@ -194,7 +193,6 @@ impl Stream {
         path.set_extension("mp4");
         self.internal_download_to(&path, channel)
             .await
-            .map(|_| path)
     }
 
     /// Attempts to downloads the [`Stream`]s resource.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -330,8 +330,9 @@ impl Stream {
                 .await?;
             #[cfg(feature = "callback")]
             if let Some(channel) = &channel {
+                // network chunks of ~10kb size
                 counter += chunk.len();
-                // Will continue even if the receiver is closed
+                // Will abort if the receiver is closed
                 // Will ignore if the channel is full and thus not slow down the download
                 if let Err(TrySendError::Closed(_)) = channel.try_send(InternalSignal::Value(counter)) {
                     return Err(Error::ChannelClosed)


### PR DESCRIPTION
- removed the `task::spawn` and thus the requirement to be `'static` and
  the requirement to be inside a `tokio::task::LocalSet`
  (the latter one is the reason for this PR)
- moved `Stream::*_callback` to callback module
- less callback related code in non callback Stream
- added `InternalSignals` to gracefully shut down a channel reader
- added `InternalCommunication` type to have less repetition and even a
  better non-callback-feature version
- moved most of the callback handling logic into Stream::wrap_callback
  which works with `join` instead of `task::spawn` and is much cleaner due
  to no `Option<Callback>` but rather a `Callback` in the context
- should not break existing APIs