### PR TITLE
Adapt to YouTube api v1 (#30)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ download = [
 ]
 # could be usefull if you don't want to download videos, but just want to get information like title, view-count, ...
 fetch = [
-    "tokio/macros", "reqwest",
+    "tokio/macros", "reqwest/json",
     "serde/default", "serde/rc", "serde_with/json", "serde_json", "serde_qs", "bytes", "chrono", "mime",
     "std", "descramble", "url/serde", "reqwest/cookies", "reqwest/stream", "reqwest/gzip"
 ]

--- a/src/descrambler/mod.rs
+++ b/src/descrambler/mod.rs
@@ -7,7 +7,6 @@ use cipher::Cipher;
 
 use crate::{IdBuf, Stream, Video, VideoDetails, VideoInfo};
 use crate::error::Error;
-use crate::video_info::player_response::streaming_data::RawFormat;
 use crate::video_info::player_response::streaming_data::StreamingData;
 
 mod cipher;
@@ -101,11 +100,6 @@ impl VideoDescrambler {
                 "VideoInfo contained no StreamingData, which is essential for downloading.".into()
             ))?;
 
-        if let Some(ref adaptive_fmts_raw) = self.video_info.adaptive_fmts_raw {
-            // fixme: this should probably be part of fetch.
-            apply_descrambler_adaptive_fmts(streaming_data, adaptive_fmts_raw)?;
-        }
-
         apply_signature(streaming_data, &self.js)?;
         let mut streams = Vec::new();
         Self::initialize_streams(
@@ -162,25 +156,6 @@ impl VideoDescrambler {
             streams.push(stream);
         }
     }
-}
-
-/// Extracts the [`RawFormat`]s from `adaptive_fmts_raw`. (This may be a legacy thing) 
-#[inline]
-fn apply_descrambler_adaptive_fmts(streaming_data: &mut StreamingData, adaptive_fmts_raw: &str) -> crate::Result<()> {
-    for raw_fmt in adaptive_fmts_raw.split(',') {
-        // fixme: this implementation is likely wrong. 
-        // main question: is adaptive_fmts_raw a list of normal RawFormats?
-        // To make is correct, I would need sample data for adaptive_fmts_raw
-        log::warn!(
-            "`apply_descrambler_adaptive_fmts` is probaply broken!\
-             Please open an issue on GitHub and paste in the whole warning message (it may be quite long).\
-             adaptive_fmts_raw: `{}`", raw_fmt
-        );
-        let raw_format = serde_qs::from_str::<RawFormat>(raw_fmt)?;
-        streaming_data.formats.push(raw_format);
-    }
-
-    Ok(())
 }
 
 /// Descrambles the signature of a video.

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -550,7 +550,7 @@ fn is_json_object_end(curr_char: u8, skip: &mut bool, stack: &mut Vec<u8>) -> bo
 }
 
 pub fn recommended_cookies() -> reqwest::cookie::Jar {
-    let cookie = "CONSENT=YES+; Path=/; Domain=www.youtube.com; Secure; Expires=Sun, 10 Jan 2038 07:59:59 GMT;";
+    let cookie = "CONSENT=YES+; Path=/; Domain=youtube.com; Secure; Expires=Fri, 01 Jan 2038 00:00:00 GMT;";
     let url = "https://youtube.com".parse().unwrap();
 
     let jar = reqwest::cookie::Jar::default();

--- a/src/video_info/mod.rs
+++ b/src/video_info/mod.rs
@@ -12,8 +12,6 @@ pub mod player_response;
 pub struct VideoInfo {
     #[serde_as(deserialize_as = "JsonString")]
     pub player_response: PlayerResponse,
-    #[serde(rename = "adaptive_fmts")]
-    pub adaptive_fmts_raw: Option<String>,
 
     #[serde(skip)]
     pub is_age_restricted: bool,

--- a/src/video_info/mod.rs
+++ b/src/video_info/mod.rs
@@ -1,16 +1,13 @@
 //! All the types, that hold video information.
 
 use serde::{Deserialize, Serialize};
-use serde_with::{json::JsonString, serde_as};
 
 use player_response::PlayerResponse;
 
 pub mod player_response;
 
-#[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct VideoInfo {
-    #[serde_as(deserialize_as = "JsonString")]
     pub player_response: PlayerResponse,
 
     #[serde(skip)]


### PR DESCRIPTION
This fixes the problem that YouTube apparently dropped support for `/get_video_info`.

Closes #30