### PR TITLE
Replace most nightly features with stable alternatives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ env_logger = "0.9.0"
 tokio = { version = "1.12.0", features = ["full"] }
 tokio-test = "0.4.2"
 
+[build-dependencies]
+rustc_version = "0.4.0"
+
 [features]
 # By default, the minimal features for downloading a video are enabled. If you compile with default-features = false,
 # you get only the Id type as well as the Error type.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = { version = "1.0.30", optional = true }
 tokio = { version = "1.12.0", optional = true }
 tokio-stream = { version = "0.1.7", optional = true }
 url = "2.2.2"
+once_cell = "1.12.0"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // Set cfg flags depending on release channel
+    let channel = match version_meta().unwrap().channel {
+        Channel::Stable => "CHANNEL_STABLE",
+        Channel::Beta => "CHANNEL_BETA",
+        Channel::Nightly => "CHANNEL_NIGHTLY",
+        Channel::Dev => "CHANNEL_DEV",
+    };
+    println!("cargo:rustc-cfg={}", channel)
+}

--- a/cli/src/args/stream_filter.rs
+++ b/cli/src/args/stream_filter.rs
@@ -71,10 +71,10 @@ impl StreamFilter {
             .map(|q| stream.quality == q)
             .unwrap_or(true);
         let video_quality_ok = self.video_quality
-            .map(|ref q| stream.quality_label.contains(q))
+            .map(|ref q| stream.quality_label.as_ref() == Some(q))
             .unwrap_or(true);
         let audio_quality_ok = self.audio_quality
-            .map(|ref q| stream.audio_quality.contains(q))
+            .map(|ref q| stream.audio_quality.as_ref() == Some(q))
             .unwrap_or(true);
 
         let quality_ok = quality_ok && video_quality_ok && audio_quality_ok;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(option_result_contains)]
-
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -39,7 +39,7 @@
 //! and block on the provided future (You can also use it for other asynchronous stuff, not related 
 //! to `rustube`).
 
-use std::lazy::SyncLazy;
+use once_cell::sync::Lazy;
 
 use tokio::runtime::Runtime;
 
@@ -57,7 +57,7 @@ pub use fetcher::VideoFetcher;
 pub use video::Video;
 
 /// A [`Runtime`](tokio::runtime::Runtime) for executing asynchronous code. 
-pub static RT: SyncLazy<Runtime> = SyncLazy::new(||
+pub static RT: Lazy<Runtime> = Lazy::new(||
     Runtime::new().expect("Unable to start the tokio Runtime")
 );
 

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -45,15 +45,12 @@ use tokio::runtime::Runtime;
 
 #[doc(inline)]
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub use descrambler::VideoDescrambler;
 #[doc(inline)]
 #[cfg(feature = "fetch")]
-#[doc(cfg(feature = "fetch"))]
 pub use fetcher::VideoFetcher;
 #[doc(inline)]
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub use video::Video;
 
 /// A [`Runtime`](tokio::runtime::Runtime) for executing asynchronous code. 
@@ -63,7 +60,6 @@ pub static RT: Lazy<Runtime> = Lazy::new(||
 
 /// A convenient macro for executing asynchronous code in a synchronous context.
 #[macro_export]
-#[doc(cfg(feature = "blocking"))]
 #[cfg(feature = "blocking")]
 macro_rules! block {
     (async $future:block) => { $crate::blocking::RT.block_on(async $future) };
@@ -77,22 +73,18 @@ macro_rules! block {
 
 #[doc(hidden)]
 #[cfg(feature = "fetch")]
-#[doc(cfg(feature = "fetch"))]
 pub mod fetcher;
 #[doc(hidden)]
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub mod descrambler;
 #[doc(hidden)]
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub mod video;
 
 
 /// A synchronous wrapper around [`download_best_quality`](crate::download_best_quality).
 #[inline]
 #[cfg(all(feature = "download", feature = "regex"))]
-#[doc(cfg(all(feature = "download", feature = "regex")))]
 pub fn download_best_quality(video_identifier: &str) -> crate::Result<std::path::PathBuf> {
     block!(crate::download_best_quality(video_identifier))
 }
@@ -100,7 +92,6 @@ pub fn download_best_quality(video_identifier: &str) -> crate::Result<std::path:
 /// A synchronous wrapper around [`download_worst_quality`](crate::download_worst_quality).
 #[inline]
 #[cfg(all(feature = "download", feature = "regex"))]
-#[doc(cfg(all(feature = "download", feature = "regex")))]
 pub fn download_worst_quality(video_identifier: &str) -> crate::Result<std::path::PathBuf> {
     block!(crate::download_worst_quality(video_identifier))
 }

--- a/src/descrambler/cipher.rs
+++ b/src/descrambler/cipher.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::lazy::SyncLazy;
+use once_cell::sync::Lazy;
 
 use regex::Regex;
 
@@ -7,7 +7,7 @@ use crate::{Error, Result, TryCollect};
 
 pub(crate) type TransformerFn = (fn(&mut Vec<u8>, Option<isize>), &'static str);
 
-static JS_FUNCTION_REGEX: SyncLazy<Regex> = SyncLazy::new(||
+static JS_FUNCTION_REGEX: Lazy<Regex> = Lazy::new(||
     Regex::new(r"\w+\.(\w+)\(\w,(\d+)\)").unwrap()
 );
 
@@ -152,7 +152,7 @@ fn get_transform_plan(js: &str) -> Result<Vec<String>> {
 }
 
 fn get_initial_function_name(js: &str) -> Result<&str> {
-    static FUNCTION_PATTERNS: SyncLazy<[Regex; 12]> = SyncLazy::new(|| [
+    static FUNCTION_PATTERNS: Lazy<[Regex; 12]> = Lazy::new(|| [
         Regex::new(r"\b[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*encodeURIComponent\s*\(\s*(?P<sig>[a-zA-Z0-9$]+)\(").unwrap(),
         Regex::new(r"\b[a-zA-Z0-9]+\s*&&\s*[a-zA-Z0-9]+\.set\([^,]+\s*,\s*encodeURIComponent\s*\(\s*(?P<sig>[a-zA-Z0-9$]+)\(").unwrap(),
         Regex::new(r#"(?:\b|[^a-zA-Z0-9$])(?P<sig>[a-zA-Z0-9$]{2})\s*=\s*function\(\s*a\s*\)\s*\{\s*a\s*=\s*a\.split\(\s*""\s*\)"#).unwrap(),
@@ -198,7 +198,7 @@ fn get_transform_map(js: &str, var: &str) -> Result<HashMap<String, TransformerF
 
 #[allow(clippy::ptr_arg)]
 fn map_functions(js_func: &str) -> Result<TransformerFn> {
-    static MAPPER: SyncLazy<[(Regex, TransformerFn); 4]> = SyncLazy::new(|| [
+    static MAPPER: Lazy<[(Regex, TransformerFn); 4]> = Lazy::new(|| [
         // function(a){a.reverse()}
         (Regex::new(r"\{\w\.reverse\(\)}").unwrap(), (reverse, "reverse")),
         // function(a,b){a.splice(0,b)}

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,31 +6,25 @@ pub enum Error {
     #[error("the provided raw Id does not match any known Id-pattern")]
     BadIdFormat,
     #[cfg(feature = "fetch")]
-    #[doc(cfg(feature = "fetch"))]
     #[error("the video you requested is unavailable:\n{0:#?}")]
     VideoUnavailable(Box<crate::video_info::player_response::playability_status::PlayabilityStatus>),
     #[cfg(feature = "download")]
-    #[doc(cfg(feature = "download"))]
     #[error("the video contains no streams")]
     NoStreams,
 
     #[error(transparent)]
     #[cfg(feature = "fetch")]
-    #[doc(cfg(feature = "fetch"))]
     IO(#[from] std::io::Error),
     #[error(transparent)]
     #[cfg(feature = "fetch")]
-    #[doc(cfg(feature = "fetch"))]
     Request(#[from] reqwest::Error),
     #[error("YouTube returned an unexpected response: `{0}`")]
     UnexpectedResponse(Cow<'static, str>),
     #[error(transparent)]
     #[cfg(feature = "fetch")]
-    #[doc(cfg(feature = "fetch"))]
     QueryDeserialization(#[from] serde_qs::Error),
     #[error(transparent)]
     #[cfg(feature = "fetch")]
-    #[doc(cfg(feature = "fetch"))]
     JsonDeserialization(#[from] serde_json::Error),
     #[error(transparent)]
     UrlParseError(#[from] url::ParseError),
@@ -46,6 +40,5 @@ pub enum Error {
     Internal(&'static str),
     #[error("The internal channel has been closed")]
     #[cfg(feature = "callback")]
-    #[doc(cfg(feature = "callback"))]
     ChannelClosed,
 }

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -78,7 +78,6 @@ impl VideoFetcher {
     /// - When [`Id::from_raw`] fails to extracted the videos id from the url.
     /// - When [`reqwest`] fails to initialize an new [`Client`].
     #[inline]
-    #[doc(cfg(feature = "regex"))]
     #[cfg(feature = "regex")]
     pub fn from_url(url: &Url) -> crate::Result<Self> {
         let id = Id::from_raw(url.as_str())?
@@ -127,7 +126,6 @@ impl VideoFetcher {
     /// When having a good internet connection, only errors due to inaccessible videos should occur.
     /// Other errors usually mean, that YouTube changed their API, and `rustube` did not adapt to
     /// this change yet. Please feel free to open a GitHub issue if this is the case.
-    #[doc(cfg(feature = "fetch"))]
     #[cfg(feature = "fetch")]
     #[log_derive::logfn(ok = "Trace", err = "Error")]
     #[log_derive::logfn_inputs(Trace)]
@@ -173,7 +171,6 @@ impl VideoFetcher {
     /// When having a good internet connection, this method should not fail. Errors usually mean,
     /// that YouTube changed their API, and `rustube` did not adapt to this change yet. Please feel
     /// free to open a GitHub issue if this is the case.
-    #[doc(cfg(feature = "fetch"))]
     #[cfg(feature = "fetch")]
     pub async fn fetch_info(self) -> crate::Result<VideoInfo> {
         let watch_html = self.get_html(&self.watch_url).await?;

--- a/src/id.rs
+++ b/src/id.rs
@@ -25,7 +25,7 @@ pub type IdBuf = Id<'static>;
 /// - The captured id will always match following regex (defined in [ID_PATTERN]): `^[a-zA-Z0-9_-]{11}$`
 #[cfg(feature = "regex")]
 #[doc(cfg(feature = "regex"))]
-pub static ID_PATTERNS: [&std::lazy::SyncLazy<Regex>; 5] = [
+pub static ID_PATTERNS: [&once_cell::sync::Lazy<Regex>; 5] = [
     &WATCH_URL_PATTERN,
     &SHORTS_URL_PATTERN,
     &EMBED_URL_PATTERN,
@@ -35,34 +35,34 @@ pub static ID_PATTERNS: [&std::lazy::SyncLazy<Regex>; 5] = [
 /// A pattern matching the watch url of a video (i.e. `youtube.com/watch?v=<ID>`).
 #[cfg(feature = "regex")]
 #[doc(cfg(feature = "regex"))]
-pub static WATCH_URL_PATTERN: std::lazy::SyncLazy<Regex> = std::lazy::SyncLazy::new(||
+pub static WATCH_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // watch url    (i.e. https://youtube.com/watch?v=video_id)
     Regex::new(r"^(https?://)?(www\.)?youtube.\w\w\w?/watch\?v=(?P<id>[a-zA-Z0-9_-]{11})(&.*)?$").unwrap()
 );
 /// A pattern matching the shorts url of a video (i.e. `https://youtube.com/shorts/<ID>`).
 #[cfg(feature = "regex")]
 #[doc(cfg(feature = "regex"))]
-pub static SHORTS_URL_PATTERN: std::lazy::SyncLazy<Regex> = std::lazy::SyncLazy::new(||
+pub static SHORTS_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     Regex::new(r"^(https?://)?(www\.)?youtube.\w\w\w?/shorts/(?P<id>[a-zA-Z0-9_-]{11})(\?.*)?$").unwrap()
 );
 /// A pattern matching the embedded url of a video (i.e. `youtube.com/embed/<ID>`).
 #[cfg(feature = "regex")]
 #[doc(cfg(feature = "regex"))]
-pub static EMBED_URL_PATTERN: std::lazy::SyncLazy<Regex> = std::lazy::SyncLazy::new(||
+pub static EMBED_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // embed url    (i.e. https://youtube.com/embed/video_id)
     Regex::new(r"^(https?://)?(www\.)?youtube.\w\w\w?/embed/(?P<id>[a-zA-Z0-9_-]{11})\\?(\?.*)?$").unwrap()
 );
 /// A pattern matching the embedded url of a video (i.e. `youtu.be/<ID>`).
 #[cfg(feature = "regex")]
 #[doc(cfg(feature = "regex"))]
-pub static SHARE_URL_PATTERN: std::lazy::SyncLazy<Regex> = std::lazy::SyncLazy::new(||
+pub static SHARE_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // share url    (i.e. https://youtu.be/video_id)
     Regex::new(r"^(https?://)?youtu\.be/(?P<id>[a-zA-Z0-9_-]{11})$").unwrap()
 );
 /// A pattern matching the id of a video (`^[a-zA-Z0-9_-]{11}$`).
 #[cfg(feature = "regex")]
 #[doc(cfg(feature = "regex"))]
-pub static ID_PATTERN: std::lazy::SyncLazy<Regex> = std::lazy::SyncLazy::new(||
+pub static ID_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // id          (i.e. video_id)
     Regex::new("^(?P<id>[a-zA-Z0-9_-]{11})$").unwrap()
 );
@@ -151,12 +151,12 @@ impl<'a> Id<'a> {
 impl<'a> Id<'a> {
     #[inline]
     pub fn is_borrowed(&self) -> bool {
-        self.0.is_borrowed()
+        matches!(self.0, Cow::Borrowed(_))
     }
 
     #[inline]
     pub fn is_owned(&self) -> bool {
-        self.0.is_owned()
+        matches!(self.0, Cow::Owned(_))
     }
 
     #[inline]

--- a/src/id.rs
+++ b/src/id.rs
@@ -24,7 +24,6 @@ pub type IdBuf = Id<'static>;
 /// - each pattern contains an `id` group that will always capture when the pattern matches
 /// - The captured id will always match following regex (defined in [ID_PATTERN]): `^[a-zA-Z0-9_-]{11}$`
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
 pub static ID_PATTERNS: [&once_cell::sync::Lazy<Regex>; 5] = [
     &WATCH_URL_PATTERN,
     &SHORTS_URL_PATTERN,
@@ -34,34 +33,29 @@ pub static ID_PATTERNS: [&once_cell::sync::Lazy<Regex>; 5] = [
 ];
 /// A pattern matching the watch url of a video (i.e. `youtube.com/watch?v=<ID>`).
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
 pub static WATCH_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // watch url    (i.e. https://youtube.com/watch?v=video_id)
     Regex::new(r"^(https?://)?(www\.)?youtube.\w\w\w?/watch\?v=(?P<id>[a-zA-Z0-9_-]{11})(&.*)?$").unwrap()
 );
 /// A pattern matching the shorts url of a video (i.e. `https://youtube.com/shorts/<ID>`).
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
 pub static SHORTS_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     Regex::new(r"^(https?://)?(www\.)?youtube.\w\w\w?/shorts/(?P<id>[a-zA-Z0-9_-]{11})(\?.*)?$").unwrap()
 );
 /// A pattern matching the embedded url of a video (i.e. `youtube.com/embed/<ID>`).
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
 pub static EMBED_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // embed url    (i.e. https://youtube.com/embed/video_id)
     Regex::new(r"^(https?://)?(www\.)?youtube.\w\w\w?/embed/(?P<id>[a-zA-Z0-9_-]{11})\\?(\?.*)?$").unwrap()
 );
 /// A pattern matching the embedded url of a video (i.e. `youtu.be/<ID>`).
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
 pub static SHARE_URL_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // share url    (i.e. https://youtu.be/video_id)
     Regex::new(r"^(https?://)?youtu\.be/(?P<id>[a-zA-Z0-9_-]{11})$").unwrap()
 );
 /// A pattern matching the id of a video (`^[a-zA-Z0-9_-]{11}$`).
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
 pub static ID_PATTERN: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(||
     // id          (i.e. video_id)
     Regex::new("^(?P<id>[a-zA-Z0-9_-]{11})$").unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
-#![feature(
-doc_cfg,
-)]
+// `CHANNEL_NIGHTLY` is passed by `build.rs`
+// Credits: https://blog.wnut.pw/2020/03/24/documentation-and-unstable-rustdoc-features/
+#![cfg_attr(all(doc, CHANNEL_NIGHTLY), feature(doc_auto_cfg))]
+
 #![allow(clippy::nonstandard_macro_braces, clippy::derive_partial_eq_without_eq)]
 #![warn(
 missing_debug_implementations,
@@ -194,35 +195,26 @@ unreachable_pub
 extern crate alloc;
 
 #[cfg(feature = "tokio")]
-#[doc(cfg(feature = "tokio"))]
 pub use tokio;
 pub use url;
 
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub use crate::descrambler::VideoDescrambler;
 #[cfg(feature = "std")]
-#[doc(cfg(feature = "std"))]
 pub use crate::error::Error;
 #[cfg(feature = "fetch")]
-#[doc(cfg(feature = "fetch"))]
 pub use crate::fetcher::VideoFetcher;
 pub use crate::id::{Id, IdBuf};
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
 pub use crate::id::{EMBED_URL_PATTERN, ID_PATTERN, ID_PATTERNS, SHARE_URL_PATTERN, WATCH_URL_PATTERN};
 #[cfg(feature = "callback")]
-#[doc(cfg(feature = "callback"))]
 pub use crate::stream::callback::{Callback, CallbackArguments, OnCompleteType, OnProgressType};
 #[cfg(feature = "stream")]
-#[doc(cfg(feature = "stream"))]
 pub use crate::stream::Stream;
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub use crate::video::Video;
 #[doc(inline)]
 #[cfg(feature = "fetch")]
-#[doc(cfg(feature = "fetch"))]
 pub use crate::video_info::{
     player_response::{
         PlayerResponse,
@@ -232,41 +224,32 @@ pub use crate::video_info::{
 };
 #[doc(inline)]
 #[cfg(feature = "microformat")]
-#[doc(cfg(feature = "microformat"))]
 pub use crate::video_info::player_response::microformat::Microformat;
 
 /// Alias for `Result`, with the default error type [`Error`].
 #[cfg(feature = "std")]
-#[doc(cfg(feature = "std"))]
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 #[cfg(feature = "blocking")]
-#[doc(cfg(feature = "blocking"))]
 pub mod blocking;
 #[doc(hidden)]
 #[cfg(feature = "std")]
-#[doc(cfg(feature = "std"))]
 pub mod error;
 #[doc(hidden)]
 pub mod id;
 #[doc(hidden)]
 #[cfg(feature = "stream")]
-#[doc(cfg(feature = "stream"))]
 pub mod stream;
 #[cfg(feature = "fetch")]
-#[doc(cfg(feature = "fetch"))]
 pub mod video_info;
 #[doc(hidden)]
 #[cfg(feature = "fetch")]
-#[doc(cfg(feature = "fetch"))]
 pub mod fetcher;
 #[doc(hidden)]
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub mod descrambler;
 #[doc(hidden)]
 #[cfg(feature = "descramble")]
-#[doc(cfg(feature = "descramble"))]
 pub mod video;
 
 #[cfg(feature = "fetch")]
@@ -280,7 +263,6 @@ mod serde_impl;
 /// For more control over the download process have a look at the [`crate`] level documentation,
 /// or at the [`Video`] struct.
 #[cfg(all(feature = "download", feature = "regex"))]
-#[doc(cfg(all(feature = "download", feature = "regex")))]
 pub async fn download_best_quality(video_identifier: &str) -> Result<std::path::PathBuf> {
     let id = Id::from_raw(video_identifier)?;
     Video::from_id(id.into_owned())
@@ -299,7 +281,6 @@ pub async fn download_best_quality(video_identifier: &str) -> Result<std::path::
 /// For more control over the download process have a look at the [`crate`] level documentation,
 /// or at the [`Video`] struct.
 #[cfg(all(feature = "download", feature = "regex"))]
-#[doc(cfg(all(feature = "download", feature = "regex")))]
 pub async fn download_worst_quality(video_identifier: &str) -> Result<std::path::PathBuf> {
     let id = Id::from_raw(video_identifier)?;
     Video::from_id(id.into_owned())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(
-doc_cfg, async_closure, cow_is_borrowed, once_cell,
-box_syntax, str_split_as_str, option_result_contains,
+doc_cfg,
 )]
 #![allow(clippy::nonstandard_macro_braces, clippy::derive_partial_eq_without_eq)]
 #![warn(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ missing_debug_implementations,
 rust_2018_idioms,
 unreachable_pub
 )]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![doc(test(no_crate_inject))]
 
 #![cfg_attr(not(any(feature = "std", feature = "regex")), no_std)]

--- a/src/serde_impl/mime_type.rs
+++ b/src/serde_impl/mime_type.rs
@@ -1,4 +1,4 @@
-use std::lazy::SyncLazy;
+use once_cell::sync::Lazy;
 use std::str::FromStr;
 
 use mime::Mime;
@@ -11,7 +11,7 @@ use crate::video_info::player_response::streaming_data::MimeType;
 
 pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<MimeType, <D as Deserializer<'de>>::Error> where
     D: Deserializer<'de> {
-    static PATTERN: SyncLazy<Regex> = SyncLazy::new(||
+    static PATTERN: Lazy<Regex> = Lazy::new(||
         Regex::new(r#"(\w+/\w+);\scodecs="([a-zA-Z-0-9.,\s]*)""#).unwrap()
     );
 

--- a/src/stream/callback.rs
+++ b/src/stream/callback.rs
@@ -23,7 +23,6 @@ pub(crate) enum InternalSignal {
 pub(crate) type InternalSender = Sender<InternalSignal>;
 
 /// Arguments given either to a on_progress callback or on_progress receiver
-#[doc(cfg(feature = "callback"))]
 #[derive(Clone, derivative::Derivative)]
 #[derivative(Debug)]
 pub struct CallbackArguments {
@@ -34,7 +33,6 @@ pub struct CallbackArguments {
 }
 
 /// Type to process on_progress
-#[doc(cfg(feature = "callback"))]
 pub enum OnProgressType {
     /// Box containing a closure to execute on progress
     Closure(OnProgressClosure),
@@ -71,7 +69,6 @@ impl fmt::Debug for OnProgressType {
     }
 }
 
-#[doc(cfg(feature = "callback"))]
 impl Default for OnProgressType {
     fn default() -> Self {
         OnProgressType::None
@@ -79,7 +76,6 @@ impl Default for OnProgressType {
 }
 
 /// Type to process on_progress
-#[doc(cfg(feature = "callback"))]
 pub enum OnCompleteType {
     /// Box containing a closure to execute on complete
     Closure(OnCompleteClosure),
@@ -99,7 +95,6 @@ impl fmt::Debug for OnCompleteType {
     }
 }
 
-#[doc(cfg(feature = "callback"))]
 impl Default for OnCompleteType {
     fn default() -> Self {
         OnCompleteType::None
@@ -107,7 +102,6 @@ impl Default for OnCompleteType {
 }
 
 /// Methods and streams to process either on_progress or on_complete
-#[doc(cfg(feature = "callback"))]
 #[derive(Debug)]
 pub struct Callback {
     pub on_progress: OnProgressType,
@@ -116,7 +110,6 @@ pub struct Callback {
     pub(crate) internal_receiver: Option<Receiver<InternalSignal>>,
 }
 
-#[doc(cfg(feature = "callback"))]
 impl Callback {
     /// Create a new callback struct without actual callbacks
     pub fn new() -> Self {
@@ -136,7 +129,6 @@ impl Callback {
     /// If it's too slow, some on_progress events will be dropped.
     /// If you are looking fore something that will be executed more seldom, look for
     /// [Callback::connect_on_progress_closure_slow](crate::stream::callback::Callback::connect_on_progress_closure_slow)
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_progress_closure(mut self, closure: impl Fn(CallbackArguments) + 'static) -> Self {
@@ -146,7 +138,6 @@ impl Callback {
 
     /// Attach a closure to be executed on progress. This closure will be executed
     /// more seldom, around once for every MB downloaded.
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_progress_closure_slow(mut self, closure: impl Fn(CallbackArguments) + 'static) -> Self {
@@ -161,7 +152,6 @@ impl Callback {
     /// If it's too slow, some on_progress events will be dropped.
     /// If you are looking fore something that will be executed more seldom, look for
     /// [Callback::connect_on_progress_closure_async_slow](crate::stream::callback::Callback::connect_on_progress_closure_async_slow)
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_progress_closure_async<Fut: Future<Output=()> + Send + 'static, F: Fn(CallbackArguments) -> Fut + 'static>(mut self, closure: F) -> Self {
@@ -171,7 +161,6 @@ impl Callback {
 
     /// Attach a async closure to be executed on progress. This closure will be executed
     /// more seldom, around once for every MB downloaded.
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_progress_closure_async_slow<Fut: Future<Output=()> + Send + 'static, F: Fn(CallbackArguments) -> Fut + 'static + Sync + Send>(mut self, closure: F) -> Self {
@@ -185,7 +174,6 @@ impl Callback {
     /// ### Warning:
     /// This sender gets messages quite often, once every ~10kB progress.
     /// If it's too slow, some on_progress events will be dropped.
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_progress_sender(
@@ -201,7 +189,6 @@ impl Callback {
     /// cancel_or_close indicates whether or not to cancel the download, if the receiver is closed
     ///
     /// This closure will be executed more seldom, around once for every MB downloaded.
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_progress_sender_slow(
@@ -214,7 +201,6 @@ impl Callback {
     }
 
     /// Attach a closure to be executed on complete
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_complete_closure(mut self, closure: impl Fn(Option<PathBuf>) + 'static) -> Self {
@@ -223,7 +209,6 @@ impl Callback {
     }
 
     /// Attach a async closure to be executed on complete
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     #[must_use]
     pub fn connect_on_complete_closure_async<Fut: Future<Output=()> + Send + 'static, F: Fn(Option<PathBuf>) -> Fut + 'static>(mut self, closure: F) -> Self {
@@ -242,7 +227,6 @@ impl super::Stream {
     /// Attempts to downloads the [`Stream`](super::Stream)s resource.
     /// This will download the video to <video_id>.mp4 in the current working directory.
     /// Takes an [`Callback`](crate::stream::callback::Callback)
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     pub async fn download_with_callback(&self, callback: Callback) -> Result<PathBuf> {
         self.wrap_callback(|channel| {
@@ -253,7 +237,6 @@ impl super::Stream {
     /// Attempts to downloads the [`Stream`](super::Stream)s resource.
     /// This will download the video to <video_id>.mp4 in the provided directory.
     /// Takes an [`Callback`](crate::stream::callback::Callback)
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     pub async fn download_to_dir_with_callback<P: AsRef<Path>>(
         &self,
@@ -268,7 +251,6 @@ impl super::Stream {
     /// Attempts to downloads the [`Stream`](super::Stream)s resource.
     /// This will download the video to the provided file path.
     /// Takes an [`Callback`](crate::stream::callback::Callback)
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     pub async fn download_to_with_callback<P: AsRef<Path>>(&self, path: P, callback: Callback) -> Result<()> {
         let _ = self.wrap_callback(|channel| {

--- a/src/stream/callback.rs
+++ b/src/stream/callback.rs
@@ -165,7 +165,7 @@ impl Callback {
     #[inline]
     #[must_use]
     pub fn connect_on_progress_closure_async<Fut: Future<Output=()> + Send + 'static, F: Fn(CallbackArguments) -> Fut + 'static>(mut self, closure: F) -> Self {
-        self.on_progress = OnProgressType::AsyncClosure(box move |arg| closure(arg).boxed());
+        self.on_progress = OnProgressType::AsyncClosure(Box::new(move |arg| closure(arg).boxed()));
         self
     }
 
@@ -175,7 +175,7 @@ impl Callback {
     #[inline]
     #[must_use]
     pub fn connect_on_progress_closure_async_slow<Fut: Future<Output=()> + Send + 'static, F: Fn(CallbackArguments) -> Fut + 'static + Sync + Send>(mut self, closure: F) -> Self {
-        self.on_progress = OnProgressType::SlowAsyncClosure(box move |arg| closure(arg).boxed());
+        self.on_progress = OnProgressType::SlowAsyncClosure(Box::new(move |arg| closure(arg).boxed()));
         self
     }
 
@@ -227,7 +227,7 @@ impl Callback {
     #[inline]
     #[must_use]
     pub fn connect_on_complete_closure_async<Fut: Future<Output=()> + Send + 'static, F: Fn(Option<PathBuf>) -> Fut + 'static>(mut self, closure: F) -> Self {
-        self.on_complete = OnCompleteType::AsyncClosure(box move |arg| closure(arg).boxed());
+        self.on_complete = OnCompleteType::AsyncClosure(Box::new(move |arg| closure(arg).boxed()));
         self
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -110,7 +110,7 @@ impl Stream {
             high_replication: raw_format.high_replication,
             index_range: raw_format.index_range,
             init_range: raw_format.init_range,
-            is_otf: raw_format.format_type.contains(&FormatType::Otf),
+            is_otf: matches!(raw_format.format_type, Some(FormatType::Otf)),
             itag: raw_format.itag,
             last_modified: raw_format.last_modified,
             loudness_db: raw_format.loudness_db,
@@ -220,7 +220,7 @@ impl Stream {
                 log::debug!("downloaded stream {:?}", &self);
                 Ok(())
             }
-            Err(Error::Request(e)) if e.status().contains(&reqwest::StatusCode::NOT_FOUND) => {
+            Err(Error::Request(e)) if matches!(e.status(), Some(reqwest::StatusCode::NOT_FOUND)) => {
                 log::error!("failed to download {}: {:?}", self.video_details.video_id, e);
                 log::info!("try to download {} using sequenced download", self.video_details.video_id);
                 // Some adaptive streams need to be requested with sequence numbers

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -34,7 +34,6 @@ use crate::{
 };
 
 #[cfg(feature = "callback")]
-#[doc(cfg(feature = "callback"))]
 pub mod callback;
 
 // todo:
@@ -129,7 +128,6 @@ impl Stream {
 // todo: blocking download
 
 #[cfg(feature = "download")]
-#[doc(cfg(feature = "download"))]
 impl Stream {
     /// The content length of the video.
     /// If the content length was not included in the [`RawFormat`], this method will make a `HEAD`
@@ -369,7 +367,6 @@ impl Stream {
 }
 
 #[cfg(all(feature = "download", feature = "blocking"))]
-#[doc(cfg(all(feature = "download", feature = "blocking")))]
 impl Stream {
     /// A synchronous wrapper around [`Stream::download`](crate::Stream::download).
     #[inline]
@@ -379,7 +376,6 @@ impl Stream {
 
     /// A synchronous wrapper around [`Stream::download_with_callback`](crate::Stream::download_with_callback).
     #[cfg(feature = "callback")]
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     pub fn blocking_download_with_callback(&self, callback: Callback) -> Result<PathBuf> {
         crate::block!(self.download_with_callback(callback))
@@ -393,7 +389,6 @@ impl Stream {
 
     /// A synchronous wrapper around [`Stream::download_to_dir_with_callback`](crate::Stream::download_to_dir_with_callback).
     #[cfg(feature = "callback")]
-    #[doc(cfg(feature = "callback"))]
     #[inline]
     pub fn blocking_download_to_dir_with_callback<P: AsRef<Path>>(
         &self,
@@ -410,7 +405,6 @@ impl Stream {
 
     /// A synchronous wrapper around [`Stream::download_to_with_callback`](crate::Stream::download_to_with_callback).
     #[cfg(feature = "callback")]
-    #[doc(cfg(feature = "callback"))]
     pub fn blocking_download_to_with_callback<P: AsRef<Path>>(&self, path: P, callback: Callback) -> Result<()> {
         crate::block!(self.download_to_with_callback(path, callback))
     }

--- a/src/video.rs
+++ b/src/video.rs
@@ -98,8 +98,7 @@ impl Video {
     /// - When [`VideoDescrambler::descramble`](crate::VideoDescrambler::descramble) fails.
     #[inline]
     #[cfg(all(feature = "download", feature = "regex"))]
-    #[doc(cfg(all(feature = "download", feature = "regex")))]
-    pub async fn from_url(url: &url::Url) -> crate::Result<Self> {
+        pub async fn from_url(url: &url::Url) -> crate::Result<Self> {
         crate::VideoFetcher::from_url(url)?
             .fetch()
             .await?
@@ -112,8 +111,7 @@ impl Video {
     /// - When [`VideoDescrambler::descramble`](crate::VideoDescrambler::descramble) fails.
     #[inline]
     #[cfg(feature = "download")]
-    #[doc(cfg(feature = "download"))]
-    pub async fn from_id(id: crate::IdBuf) -> crate::Result<Self> {
+        pub async fn from_id(id: crate::IdBuf) -> crate::Result<Self> {
         crate::VideoFetcher::from_id(id)?
             .fetch()
             .await?

--- a/src/video.rs
+++ b/src/video.rs
@@ -98,7 +98,7 @@ impl Video {
     /// - When [`VideoDescrambler::descramble`](crate::VideoDescrambler::descramble) fails.
     #[inline]
     #[cfg(all(feature = "download", feature = "regex"))]
-        pub async fn from_url(url: &url::Url) -> crate::Result<Self> {
+    pub async fn from_url(url: &url::Url) -> crate::Result<Self> {
         crate::VideoFetcher::from_url(url)?
             .fetch()
             .await?
@@ -111,7 +111,7 @@ impl Video {
     /// - When [`VideoDescrambler::descramble`](crate::VideoDescrambler::descramble) fails.
     #[inline]
     #[cfg(feature = "download")]
-        pub async fn from_id(id: crate::IdBuf) -> crate::Result<Self> {
+    pub async fn from_id(id: crate::IdBuf) -> crate::Result<Self> {
         crate::VideoFetcher::from_id(id)?
             .fetch()
             .await?

--- a/src/video_info/player_response/mod.rs
+++ b/src/video_info/player_response/mod.rs
@@ -12,7 +12,6 @@ pub mod video_details;
 pub mod streaming_data;
 pub mod playability_status;
 #[cfg(feature = "microformat")]
-#[doc(cfg(feature = "microformat"))]
 pub mod microformat;
 
 
@@ -28,7 +27,6 @@ pub struct PlayerResponse {
     // endscreen: _,
     // messages: _,
     #[cfg(feature = "microformat")]
-    #[doc(cfg(feature = "microformat"))]
     pub microformat: Option<Microformat>,
     pub playability_status: PlayabilityStatus,
     // playbackTracking: _,


### PR DESCRIPTION
- option_result_contains -> matches and equality tests
- std::lazy::SyncLazy -> once_cell::sync::Lazy
- box syntax -> Box::new
- cow_is_borrowed -> matches!(cow, Cow::Borrowed)

For doc_cfg:

Use a trick with a build script from https://blog.wnut.pw/2020/03/24/documentation-and-unstable-rustdoc-features/. This will enable the doc_auto_cfg feature only when building documentation using nightly rust compiler

Also instead of explicit #[doc(cfg)] use doc_auto_cfg which will automagically figure out all the feature docs based on the existing attributes

Closes #45 