### PR TITLE
fix js deserialisation error on ultra low latency live streams

### DIFF
--- a/src/video_info/player_response/video_details.rs
+++ b/src/video_info/player_response/video_details.rs
@@ -46,6 +46,8 @@ pub enum LatencyClass {
     Low,
     #[serde(rename = "MDE_STREAM_OPTIMIZATIONS_RENDERER_LATENCY_NORMAL")]
     Normal,
+    #[serde(rename = "MDE_STREAM_OPTIMIZATIONS_RENDERER_LATENCY_ULTRA_LOW")]
+    UltraLow,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Example: https://www.youtube.com/watch?v=X437XmpsopA