### PR TITLE
Added progress bar to CLI download.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use rustc_version::{version_meta, Channel};
+use rustc_version::{Channel, version_meta};
 
 fn main() {
     // Set cfg flags depending on release channel
@@ -8,5 +8,5 @@ fn main() {
         Channel::Nightly => "CHANNEL_NIGHTLY",
         Channel::Dev => "CHANNEL_DEV",
     };
-    println!("cargo:rustc-cfg={}", channel)
+    println!("cargo:rustc-cfg={channel}");
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,11 +25,10 @@ clap = { version = "3.0.0-rc.7", features = ["derive", "wrap_help"] }
 fern = { version = "0.6.0", features = ["colored"] }
 log = "0.4.14"
 mime = "0.3.16"
-rustube = { path = "..", version = "0.6", features = ["download", "std", "callback", "stream", "blocking"] }
+rustube = { path = "..", version = "0.6", features = ["download", "std", "callback"] }
 tokio = { version = "1.12.0", features = ["rt-multi-thread"] }
 serde = "1.0.130"
 strum = { version = "0.22.0", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"
 pbr = "1.0.4"
-

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,9 +25,11 @@ clap = { version = "3.0.0-rc.7", features = ["derive", "wrap_help"] }
 fern = { version = "0.6.0", features = ["colored"] }
 log = "0.4.14"
 mime = "0.3.16"
-rustube = { path = "..", version = "0.6", features = ["download", "std"] }
+rustube = { path = "..", version = "0.6", features = ["download", "std", "callback", "stream", "blocking"] }
 tokio = { version = "1.12.0", features = ["rt-multi-thread"] }
 serde = "1.0.130"
 strum = { version = "0.22.0", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"
+pbr = "1.0.4"
+

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -71,9 +71,11 @@ async fn download(args: DownloadArgs) -> Result<()> {
 
     // handle download progress updates
     let mut callback = Callback::new();
+    let mut counter = 0;
     callback = callback.connect_on_progress_closure( move |cargs| {
         // update progress bar
-        pb.add(cargs.current_chunk as u64);
+        pb.add(cargs.current_chunk.saturating_sub(counter) as u64);
+        counter = cargs.current_chunk;
     });
 
     let output_level = args.output.output_level;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,8 +5,8 @@ use clap::Parser;
 
 use args::DownloadArgs;
 use args::StreamFilter;
-use rustube::Callback;
 use rustube::{Error, Id, IdBuf, Stream, Video, VideoFetcher, VideoInfo};
+use rustube::Callback;
 
 use crate::args::{CheckArgs, Command, FetchArgs};
 use crate::video_serializer::VideoSerializer;
@@ -65,37 +65,25 @@ async fn download(args: DownloadArgs) -> Result<()> {
     let (video_info, stream) = get_stream(id.as_owned(), args.stream_filter).await?;
     let download_path = download_path(args.filename, stream.mime.subtype().as_str(), args.dir, id);
 
-    // init CLI progress bar
-    let mut pb = pbr::ProgressBar::new(stream.content_length().await?);
-    pb.set_units(pbr::Units::Bytes);
-    pb.format("╢▌▌░╟");
+    let mut pb = args.logging.init_progress_bar(stream.content_length().await?);
+    let callback = Callback::new()
+        .connect_on_progress_closure(|cargs| {
+            // update progress bar
+            pb.add(cargs.current_chunk.saturating_sub(cargs.current_chunk) as u64);
+        });
 
-    // handle download progress updates
-    let mut callback = Callback::new();
-    let mut counter = 0;
-    callback = callback.connect_on_progress_closure( move |cargs| {
-        // update progress bar
-        pb.add(cargs.current_chunk.saturating_sub(counter) as u64);
-        counter = cargs.current_chunk;
-    });
+    stream
+        .download_to_with_callback(&download_path, callback)
+        .await?;
+    pb.finish_println(&format!("Finished downloading video to {download_path:?}\n"));
 
-    let output_level = args.output.output_level;
-    let output = args.output;
-    let handle = std::thread::spawn(move || {
-        // TODO handle result
-        let _ = stream.blocking_download_to_with_callback(download_path, callback);
-
-        let video_serializer = VideoSerializer::new(
-            video_info,
-            std::iter::once(stream),
-            output_level,
-        );
-        let output = output.output_format.serialize_output(&video_serializer).unwrap();
-        println!("{}", output);
-    });
-
-    // wait for download to finish
-    let _ = handle.join();
+    let video_serializer = VideoSerializer::new(
+        video_info,
+        std::iter::once(stream),
+        args.output.output_level,
+    );
+    let output = args.output.output_format.serialize_output(&video_serializer).unwrap();
+    println!("{}", output);
 
     Ok(())
 }
@@ -126,7 +114,7 @@ async fn get_stream(id: IdBuf, stream_filter: StreamFilter) -> Result<(VideoInfo
 async fn get_streams(
     id: IdBuf,
     stream_filter: &'_ StreamFilter,
-) -> Result<(VideoInfo, impl Iterator<Item = Stream> + '_)> {
+) -> Result<(VideoInfo, impl Iterator<Item=Stream> + '_)> {
     let (video_info, streams) = get_video(id).await?.into_parts();
 
     let streams = streams

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -67,6 +67,7 @@ async fn download(args: DownloadArgs) -> Result<()> {
 
     // init CLI progress bar
     let mut pb = pbr::ProgressBar::new(stream.content_length().await?);
+    pb.set_units(pbr::Units::Bytes);
     pb.format("╢▌▌░╟");
 
     // handle download progress updates

--- a/src/stream/callback.rs
+++ b/src/stream/callback.rs
@@ -9,10 +9,10 @@ use tokio::sync::mpsc;
 
 use crate::Result;
 
-pub type OnProgressClosure = Box<dyn FnMut(CallbackArguments) + Send>;
-pub type OnProgressAsyncClosure = Box<dyn Fn(CallbackArguments) -> Pin<Box<dyn Future<Output=()> + Send>> + Send + Sync>;
-pub type OnCompleteClosure = Box<dyn Fn(Option<PathBuf>) + Send>;
-pub type OnCompleteAsyncClosure = Box<dyn Fn(Option<PathBuf>) -> Pin<Box<dyn Future<Output=()> + Send>> + Send + Sync>;
+pub type OnProgressClosure<'a> = Box<dyn FnMut(CallbackArguments) + Send + 'a>;
+pub type OnProgressAsyncClosure<'a> = Box<dyn FnMut(CallbackArguments) -> Pin<Box<dyn Future<Output=()> + Send + 'a>> + Send + Sync + 'a>;
+pub type OnCompleteClosure<'a> = Box<dyn FnMut(Option<PathBuf>) + Send + 'a>;
+pub type OnCompleteAsyncClosure<'a> = Box<dyn FnMut(Option<PathBuf>) -> Pin<Box<dyn Future<Output=()> + Send + 'a>> + Send + Sync + 'a>;
 
 #[derive(Debug)]
 pub(crate) enum InternalSignal {
@@ -33,20 +33,20 @@ pub struct CallbackArguments {
 }
 
 /// Type to process on_progress
-pub enum OnProgressType {
+pub enum OnProgressType<'a> {
     /// Box containing a closure to execute on progress
-    Closure(OnProgressClosure),
+    Closure(OnProgressClosure<'a>),
     /// Box containing a async closure to execute on progress
-    AsyncClosure(OnProgressAsyncClosure),
+    AsyncClosure(OnProgressAsyncClosure<'a>),
     /// Channel to send a message to on progress,
     /// bool indicates whether or not to cancel on a closed channel
     Channel(Sender<CallbackArguments>, bool),
     /// Box containing a closure to execute on progress
     /// Will get executed for every MB downloaded
-    SlowClosure(OnProgressClosure),
+    SlowClosure(OnProgressClosure<'a>),
     /// Box containing a async closure to execute on progress
     /// Will get executed for every MB downloaded
-    SlowAsyncClosure(OnProgressAsyncClosure),
+    SlowAsyncClosure(OnProgressAsyncClosure<'a>),
     /// Channel to send a message to on progress,
     /// bool indicates whether or not to cancel on a closed channel
     /// Will get executed for every MB downloaded
@@ -54,7 +54,7 @@ pub enum OnProgressType {
     None,
 }
 
-impl fmt::Debug for OnProgressType {
+impl<'a> fmt::Debug for OnProgressType<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             OnProgressType::AsyncClosure(_) => "AsyncClosure(async Fn)",
@@ -69,22 +69,22 @@ impl fmt::Debug for OnProgressType {
     }
 }
 
-impl Default for OnProgressType {
+impl<'a> Default for OnProgressType<'a> {
     fn default() -> Self {
         OnProgressType::None
     }
 }
 
 /// Type to process on_progress
-pub enum OnCompleteType {
+pub enum OnCompleteType<'a> {
     /// Box containing a closure to execute on complete
-    Closure(OnCompleteClosure),
+    Closure(OnCompleteClosure<'a>),
     /// Box containing a async closure to execute on complete
-    AsyncClosure(OnCompleteAsyncClosure),
+    AsyncClosure(OnCompleteAsyncClosure<'a>),
     None,
 }
 
-impl fmt::Debug for OnCompleteType {
+impl<'a> fmt::Debug for OnCompleteType<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             OnCompleteType::AsyncClosure(_) => "AsyncClosure(async Fn)",
@@ -95,7 +95,7 @@ impl fmt::Debug for OnCompleteType {
     }
 }
 
-impl Default for OnCompleteType {
+impl<'a> Default for OnCompleteType<'a> {
     fn default() -> Self {
         OnCompleteType::None
     }
@@ -103,14 +103,14 @@ impl Default for OnCompleteType {
 
 /// Methods and streams to process either on_progress or on_complete
 #[derive(Debug)]
-pub struct Callback {
-    pub on_progress: OnProgressType,
-    pub on_complete: OnCompleteType,
+pub struct Callback<'a> {
+    pub on_progress: OnProgressType<'a>,
+    pub on_complete: OnCompleteType<'a>,
     pub(crate) internal_sender: InternalSender,
     pub(crate) internal_receiver: Option<Receiver<InternalSignal>>,
 }
 
-impl Callback {
+impl<'a> Callback<'a> {
     /// Create a new callback struct without actual callbacks
     pub fn new() -> Self {
         let (tx, rx) = mpsc::channel(100);
@@ -131,7 +131,7 @@ impl Callback {
     /// [Callback::connect_on_progress_closure_slow](crate::stream::callback::Callback::connect_on_progress_closure_slow)
     #[inline]
     #[must_use]
-    pub fn connect_on_progress_closure(mut self, closure: impl FnMut(CallbackArguments) + Send + 'static) -> Self {
+    pub fn connect_on_progress_closure(mut self, closure: impl FnMut(CallbackArguments) + Send + 'a) -> Self {
         self.on_progress = OnProgressType::Closure(Box::new(closure));
         self
     }
@@ -140,7 +140,7 @@ impl Callback {
     /// more seldom, around once for every MB downloaded.
     #[inline]
     #[must_use]
-    pub fn connect_on_progress_closure_slow(mut self, closure: impl Fn(CallbackArguments) + Send + 'static) -> Self {
+    pub fn connect_on_progress_closure_slow(mut self, closure: impl FnMut(CallbackArguments) + Send + 'a) -> Self {
         self.on_progress = OnProgressType::SlowClosure(Box::new(closure));
         self
     }
@@ -154,7 +154,7 @@ impl Callback {
     /// [Callback::connect_on_progress_closure_async_slow](crate::stream::callback::Callback::connect_on_progress_closure_async_slow)
     #[inline]
     #[must_use]
-    pub fn connect_on_progress_closure_async<Fut: Future<Output=()> + Send + 'static, F: Fn(CallbackArguments) -> Fut + Send + Sync + 'static>(mut self, closure: F) -> Self {
+    pub fn connect_on_progress_closure_async<Fut: Future<Output=()> + Send + 'a, F: Fn(CallbackArguments) -> Fut + Send + Sync + 'a>(mut self, closure: F) -> Self {
         self.on_progress = OnProgressType::AsyncClosure(Box::new(move |arg| closure(arg).boxed()));
         self
     }
@@ -163,7 +163,7 @@ impl Callback {
     /// more seldom, around once for every MB downloaded.
     #[inline]
     #[must_use]
-    pub fn connect_on_progress_closure_async_slow<Fut: Future<Output=()> + Send + 'static, F: Fn(CallbackArguments) -> Fut + Send + Sync + 'static>(mut self, closure: F) -> Self {
+    pub fn connect_on_progress_closure_async_slow<Fut: Future<Output=()> + Send + 'a, F: Fn(CallbackArguments) -> Fut + Send + Sync + 'a>(mut self, closure: F) -> Self {
         self.on_progress = OnProgressType::SlowAsyncClosure(Box::new(move |arg| closure(arg).boxed()));
         self
     }
@@ -203,7 +203,7 @@ impl Callback {
     /// Attach a closure to be executed on complete
     #[inline]
     #[must_use]
-    pub fn connect_on_complete_closure(mut self, closure: impl Fn(Option<PathBuf>) + Send + 'static) -> Self {
+    pub fn connect_on_complete_closure(mut self, closure: impl FnMut(Option<PathBuf>) + Send + 'a) -> Self {
         self.on_complete = OnCompleteType::Closure(Box::new(closure));
         self
     }
@@ -211,13 +211,13 @@ impl Callback {
     /// Attach a async closure to be executed on complete
     #[inline]
     #[must_use]
-    pub fn connect_on_complete_closure_async<Fut: Future<Output=()> + Send + 'static, F: Fn(Option<PathBuf>) -> Fut + Send + Sync + 'static>(mut self, closure: F) -> Self {
+    pub fn connect_on_complete_closure_async<Fut: Future<Output=()> + Send + 'a, F: Fn(Option<PathBuf>) -> Fut + Send + Sync + 'a>(mut self, closure: F) -> Self {
         self.on_complete = OnCompleteType::AsyncClosure(Box::new(move |arg| closure(arg).boxed()));
         self
     }
 }
 
-impl Default for Callback {
+impl<'a> Default for Callback<'a> {
     fn default() -> Self {
         Self::new()
     }
@@ -228,7 +228,7 @@ impl super::Stream {
     /// This will download the video to <video_id>.mp4 in the current working directory.
     /// Takes an [`Callback`](crate::stream::callback::Callback)
     #[inline]
-    pub async fn download_with_callback(&self, callback: Callback) -> Result<PathBuf> {
+    pub async fn download_with_callback<'a>(&'a self, callback: Callback<'a>) -> Result<PathBuf> {
         self.wrap_callback(|channel| {
             self.internal_download(channel)
         }, callback).await
@@ -238,10 +238,10 @@ impl super::Stream {
     /// This will download the video to <video_id>.mp4 in the provided directory.
     /// Takes an [`Callback`](crate::stream::callback::Callback)
     #[inline]
-    pub async fn download_to_dir_with_callback<P: AsRef<Path>>(
-        &self,
+    pub async fn download_to_dir_with_callback<'a, P: AsRef<Path>>(
+        &'a self,
         dir: P,
-        callback: Callback,
+        callback: Callback<'a>,
     ) -> Result<PathBuf> {
         self.wrap_callback(|channel| {
             self.internal_download_to_dir(dir, channel)
@@ -252,17 +252,17 @@ impl super::Stream {
     /// This will download the video to the provided file path.
     /// Takes an [`Callback`](crate::stream::callback::Callback)
     #[inline]
-    pub async fn download_to_with_callback<P: AsRef<Path>>(&self, path: P, callback: Callback) -> Result<()> {
+    pub async fn download_to_with_callback<'a, P: AsRef<Path>>(&'a self, path: P, callback: Callback<'a>) -> Result<()> {
         let _ = self.wrap_callback(|channel| {
             self.internal_download_to(path, channel)
         }, callback).await?;
         Ok(())
     }
 
-    async fn wrap_callback<F: Future<Output=Result<PathBuf>>>(
-        &self,
+    async fn wrap_callback<'a, F: Future<Output=Result<PathBuf>>>(
+        &'a self,
         to_wrap: impl FnOnce(Option<InternalSender>) -> F,
-        mut callback: Callback,
+        mut callback: Callback<'a>,
     ) -> Result<PathBuf> {
         let wrap_fut = to_wrap(Some(callback.internal_sender.clone()));
         let aid_fut = self.on_progress(
@@ -279,7 +279,7 @@ impl super::Stream {
     }
 
     #[inline]
-    async fn on_progress(&self, mut receiver: Receiver<InternalSignal>, on_progress: OnProgressType) {
+    async fn on_progress<'a>(&'a self, mut receiver: Receiver<InternalSignal>, on_progress: OnProgressType<'a>) {
         let last_trigger = Mutex::new(0);
         let content_length = self.content_length().await.ok();
         match on_progress {
@@ -298,7 +298,7 @@ impl super::Stream {
                     }
                 }
             }
-            OnProgressType::AsyncClosure(closure) => {
+            OnProgressType::AsyncClosure(mut closure) => {
                 while let Some(data) = receiver.recv().await {
                     match data {
                         InternalSignal::Value(data) => {
@@ -350,7 +350,7 @@ impl super::Stream {
                     }
                 }
             }
-            OnProgressType::SlowAsyncClosure(closure) => {
+            OnProgressType::SlowAsyncClosure(mut closure) => {
                 while let Some(data) = receiver.recv().await {
                     match data {
                         InternalSignal::Value(data) => {
@@ -398,13 +398,13 @@ impl super::Stream {
     }
 
     #[inline]
-    async fn on_complete(on_complete: OnCompleteType, path: Option<PathBuf>) {
+    async fn on_complete(on_complete: OnCompleteType<'_>, path: Option<PathBuf>) {
         match on_complete {
             OnCompleteType::None => {}
-            OnCompleteType::Closure(closure) => {
+            OnCompleteType::Closure(mut closure) => {
                 closure(path)
             }
-            OnCompleteType::AsyncClosure(closure) => {
+            OnCompleteType::AsyncClosure(mut closure) => {
                 closure(path).await
             }
         }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -378,7 +378,7 @@ impl Stream {
     /// A synchronous wrapper around [`Stream::download_with_callback`](crate::Stream::download_with_callback).
     #[cfg(feature = "callback")]
     #[inline]
-    pub fn blocking_download_with_callback(&self, callback: Callback) -> Result<PathBuf> {
+    pub fn blocking_download_with_callback<'a>(&'a self, callback: Callback<'a>) -> Result<PathBuf> {
         crate::block!(self.download_with_callback(callback))
     }
 
@@ -391,10 +391,10 @@ impl Stream {
     /// A synchronous wrapper around [`Stream::download_to_dir_with_callback`](crate::Stream::download_to_dir_with_callback).
     #[cfg(feature = "callback")]
     #[inline]
-    pub fn blocking_download_to_dir_with_callback<P: AsRef<Path>>(
-        &self,
+    pub fn blocking_download_to_dir_with_callback<'a, P: AsRef<Path>>(
+        &'a self,
         dir: P,
-        callback: Callback,
+        callback: Callback<'a>,
     ) -> Result<PathBuf> {
         crate::block!(self.download_to_dir_with_callback(dir, callback))
     }
@@ -406,7 +406,7 @@ impl Stream {
 
     /// A synchronous wrapper around [`Stream::download_to_with_callback`](crate::Stream::download_to_with_callback).
     #[cfg(feature = "callback")]
-    pub fn blocking_download_to_with_callback<P: AsRef<Path>>(&self, path: P, callback: Callback) -> Result<()> {
+    pub fn blocking_download_to_with_callback<'a, P: AsRef<Path>>(&'a self, path: P, callback: Callback<'a>) -> Result<()> {
         crate::block!(self.download_to_with_callback(path, callback))
     }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -331,10 +331,7 @@ impl Stream {
                 // Will abort if the receiver is closed
                 // Will ignore if the channel is full and thus not slow down the download
                 if let Err(TrySendError::Closed(_)) =
-                    //channel.try_send(InternalSignal::Value(counter))
-
-                    // send current chunk length to subs
-                    channel.try_send(InternalSignal::Value(len))
+                    channel.try_send(InternalSignal::Value(counter))
                 {
                     return Err(Error::ChannelClosed);
                 }


### PR DESCRIPTION
This CLI progress bar is pretty useful for downloads.  I had to change the value sent back in the callback to be the chunk size instead of the counter. Hopefully that didn't break anything, but I didn't see any tests. 

edit: I reverted the callback to how it was before to not break existing clients. 