### PR TITLE
Add missing QualityLabel

### DIFF
--- a/src/video_info/player_response/streaming_data/mod.rs
+++ b/src/video_info/player_response/streaming_data/mod.rs
@@ -194,6 +194,8 @@ pub enum QualityLabel {
     P1080Hz60HDR,
     #[serde(rename = "1440p")]
     P1440,
+    #[serde(rename = "1440p50")]
+    P1440Hz50,
     #[serde(rename = "1440p60")]
     P1440Hz60,
     #[serde(rename = "1440p60 HDR")]


### PR DESCRIPTION
I received this error message with some videos
```
"Could not acquire the player response from the watch HTML!
It looks like YouTube changed it's API again :-/
If this not yet reported, it would be great if you could file an issue:
```

So after checking the JSON configuration, I found that the `QualityLabel` enum doesn't have this value: `1440p50`.
For this reason the deserialization failed.

Maybe related to https://github.com/DzenanJupic/rustube/issues/69